### PR TITLE
UTF-8 read and write file

### DIFF
--- a/cleaner.py
+++ b/cleaner.py
@@ -76,7 +76,7 @@ def cleanup_incubator(text):
         text = re.sub(r"\[\[ *" + key_reg + " *: *([^\|\]])", r"[[" + namespaces[key] + r":\1", text)
     return text
 
-with open(file, "r") as origin, open(resultfile, "a") as output:
+with open(file, "r", encoding="utf-8") as origin, open(resultfile, "a", encoding="utf-8") as output:
     linenumber = 0
     lines_with_prefix = []
     for line in origin:


### PR DESCRIPTION
I attempted to use this script to import content from the Incubator to the newly created [bewwiki](https://bew.wikipedia.org/). However, the script was broken because it couldn't handle special character encoding. I added a quick fix to enable it to process UTF-8 encoding. After making this modification, I successfully cleaned the bewwiki.xml file.